### PR TITLE
convert to bool

### DIFF
--- a/Mechanic.roboFontExt/lib/mechanic/views.py
+++ b/Mechanic.roboFontExt/lib/mechanic/views.py
@@ -102,7 +102,7 @@ class SettingsWindow(BaseWindowController):
     """Window to display extension settings."""
     window_title = "Mechanic Settings"
     checkbox_label = "Check for updates on startup"
-    check_on_startup = Storage.get("check_on_startup")
+    check_on_startup = bool(Storage.get("check_on_startup"))
     
     def __init__(self):
         self.configured = []


### PR DESCRIPTION
It happens when a a bool is requested from the user defaults it return
a long long, which is not good, so convert it to a bool
