### PR TITLE
Give absolute path to master.zip for "download" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Mechanic requires RoboFont 1.5 or greater.
 Installation
 ------------
 
-[Download](archive/master.zip), then double click `Mechanic.roboFontExt`.
+[Download](https://github.com/jackjennings/Mechanic/archive/master.zip), then double click `Mechanic.roboFontExt`.
 
 Features
 --------


### PR DESCRIPTION
The relative path in the readme to "Download" this gave me a 404 page, so I'm copied in the absolute link, which does work.